### PR TITLE
Fix: updateChatPreventedUrl & getPreviousMessagesV2WithRequest

### DIFF
--- a/CHRLINE/services/TalkService.py
+++ b/CHRLINE/services/TalkService.py
@@ -692,7 +692,7 @@ class TalkService(ChrHelperProtocol):
 
     def updateChatPreventedUrl(self, chatMid: str, bT: bool):
         """Update chat prevented url."""
-        return self.updateChat(chatMid, {8: {2: bT}}, 4)
+        return self.updateChat(chatMid, {8: {1: {2: bT}}}, 4)
 
     def getGroupIdsJoined(self):
         """
@@ -783,7 +783,7 @@ class TalkService(ChrHelperProtocol):
                         2,
                         [
                             [10, 1, deliveredTime],
-                            [10, 1, messageId],
+                            [10, 2, messageId],
                         ],
                     ],
                     [8, 3, messagesCount],


### PR DESCRIPTION
(1) updateChatPreventedUrl: Fixed {8: {2: bT}} → {8: {1: {2: bT}}}
    Modified the data structure for updating the chat prevented URL setting.
(2) getPreviousMessagesV2WithRequest: Fixed [10, 1, messageId] → [10, 2, messageId]
    Corrected the request parameter for retrieving previous messages.