### PR TITLE
Refactor key retrieval logic in E2EE class (e2ee.py)

### DIFF
--- a/CHRLINE/e2ee.py
+++ b/CHRLINE/e2ee.py
@@ -441,11 +441,14 @@ class E2EE(ChrHelperProtocol):
         privK = base64.b64decode(selfKey["privKey"])
         if toType == 0:
             # patch to use correct key by id
-            selfKey = self.client.getE2EESelfKeyDataByKeyId(receiverKeyId)
+            selfKeyId = receiverKeyId if messageObj.from_type == 1 else senderKeyId
+            selfKey = self.client.getE2EESelfKeyDataByKeyId(selfKeyId)
             if selfKey is None:
-                raise ValueError(f"selfKey should not be None. KeyId={receiverKeyId}")
+                raise ValueError(f"selfKey should not be None. KeyId={selfKeyId}")
             privK = base64.b64decode(selfKey["privKey"])
-            pubK = self.getE2EELocalPublicKey(_from, senderKeyId)
+            pubK = self.getE2EELocalPublicKey(
+                _from, senderKeyId if messageObj.from_type == 1 else receiverKeyId
+            )
         else:
             selfKey = self.client.getE2EESelfKeyDataByKeyId(self.__e2ee_key_id)
             if selfKey is None:


### PR DESCRIPTION
This pull request updates the logic for selecting the correct key ID when decrypting E2EE messages, ensuring that the key selection is based on the message's sender type. This change improves the accuracy and reliability of message decryption, especially in scenarios where sender and receiver key IDs may differ.

Key management and decryption logic improvements:

* In `decryptE2EEMessage`, the key ID used to retrieve self key data is now conditionally set based on `messageObj.from_type`, ensuring the correct key is used for decryption.
* The public key selection for decryption now also depends on the sender type, further aligning the decryption process with the message context.